### PR TITLE
Fix "TypeError: Cannot read property 'length' of undefined" if some command doesn't have description field

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -27,7 +27,7 @@ module.exports = {
 				if (command.hide || command.disabled) continue;
 				if (command.permission && !message.member.hasPermission(command.permission)) continue;
 
-				let desc = command.description;
+				let desc = command.description || 'No description';
 
 				if (desc.length > 50) desc = desc.substring(0, 50) + '...';
 				cmds.push(`**${config.prefix}${command.name}** **·** ${desc}`);


### PR DESCRIPTION
#### Information

- [ ] This includes major changes (breaking changes)
- [ ] This includes minor changes (minimal usage changes, minor new features)
- [x] This includes patches (bug fixes, documentation changes etc)

#### Changes made

> Updated help.js with fix

#### Confirmations

- [ ] I have updated any necessary documentation
- [ ] This uses consistent code style
- [x] This is tested and works
