### PR TITLE
Feature: add X emoji on created ticket, close with emoji

### DIFF
--- a/src/listeners/messageReactionAdd.js
+++ b/src/listeners/messageReactionAdd.js
@@ -73,6 +73,8 @@ module.exports = class MessageReactionAddEventListener extends EventListener {
 						.setDescription(i18n('ticket.claimed.description', member.toString()))
 						.setFooter(settings.footer, guild.iconURL())
 				);
+			} else if(r.emoji.name === '❌') {
+				await this.client.tickets.close(channel.id, member.user.id, guild.id);
 			} else {
 				await r.users.remove(u.id);
 			}

--- a/src/modules/tickets/manager.js
+++ b/src/modules/tickets/manager.js
@@ -120,6 +120,8 @@ module.exports = class TicketManager extends EventEmitter {
 				await sent.react('🙌');
 			}
 
+			await sent.react('❌');
+
 			let questions;
 			if (cat_row.opening_questions) {
 				questions = cat_row.opening_questions


### PR DESCRIPTION
<!--
	Thank you for contributing to Discord Tickets.
	If you haven't already, please read the CONTRIBUTING guidelines (https://github.com/discord-tickets/.github/blob/main/CONTRIBUTING.md) before creating a pull request.
	Unless this pull request is for something minor like a fixing a typo, you should create an issue first.
-->

**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [X] This includes minor changes (minimal usage changes, minor new features)
- [ ] This includes patches (bug fixes)
- [ ] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

<!-- Reference any issues here -->

**Changes made**

_messageReactionAdd.js (listeners)_
`} else if(r.emoji.name === '❌') {
    await this.client.tickets.close(channel.id, member.user.id, guild.id);
}`

_manager.js (onCreate - ticket)_
`await sent.react('❌')`

<!-- Describe your changes -->

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [ ] I have updated related documentation (if necessary)
- [ ] My changes use consistent code style
- [ ] My changes have been tested and confirmed to work
