### PR TITLE
feat(docker): create docker-compose and improve dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
-FROM node:16
+FROM node:16.6.1-buster-slim
 
 WORKDIR /usr/src/app
+
+ENV NODE_ENV production
+
 COPY package*.json ./
+RUN npm ci --production
 
-RUN npm i --production
+COPY ./src ./src
+COPY ./user ./user
 
-COPY . .
-CMD ["npm", "start"]
+USER node
+CMD ["node", "."]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ENV NODE_ENV production
 COPY package*.json ./
 RUN npm ci --production
 
+# Note: this is because currently we have a check for .env file presence
+# This should be removed if that .env check gets removed.
+COPY .env .
 COPY ./src ./src
 COPY ./user ./user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.6.1-buster-slim
+FROM node:16.11.1-buster-slim
 
 WORKDIR /usr/src/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,10 @@ services:
         container_name: "bot"
         command: "node ."
         restart: always
+        volumes: 
+            - ./logs:/usr/src/app/
         networks:
             - bot
-        env_file:
-            - ./.env
-        ports:
-            - 3000:3000
         depends_on:
             - mysql
         links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,33 @@
 version: "3.5"
 
 services:
-    mysql:
-        container_name: "mysql"
-        image: mysql:8
-        networks:
-            - bot
-        restart: always
-        environment:
-          - MYSQL_ROOT_PASSWORD=MYSQL_ROOT_PASSWORD
-        volumes:
-            - mysql:/var/lib/mysql
+  mysql:
+    container_name: "mysql"
+    image: mysql:8
+    networks:
+      - bot
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=MYSQL_ROOT_PASSWORD
+    volumes:
+      - mysql:/var/lib/mysql
 
-    bot:
-        build: .
-        container_name: "bot"
-        command: "node ."
-        restart: always
-        volumes: 
-            - ./logs:/usr/src/app/
-        networks:
-            - bot
-        depends_on:
-            - mysql
-        links:
-            - mysql
+  bot:
+    build: .
+    container_name: "bot"
+    command: "node ."
+    restart: always
+    volumes:
+      - ./logs:/usr/src/app/
+    networks:
+      - bot
+    depends_on:
+      - mysql
+    links:
+      - mysql
 
 volumes:
-    mysql: ~
+  mysql: ~
 
 networks:
-    bot: 
+  bot:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.5"
+
+services:
+    mysql:
+        container_name: "mysql"
+        image: mysql:8
+        networks:
+            - bot
+        restart: always
+        environment:
+          - MYSQL_ROOT_PASSWORD=MYSQL_ROOT_PASSWORD
+        volumes:
+            - mysql:/data/db
+
+    bot:
+        build: .
+        container_name: "bot"
+        command: "node ."
+        restart: always
+        networks:
+            - bot
+        env_file:
+            - ./.env
+        ports:
+            - 3000:3000
+        depends_on:
+            - mysql
+        links:
+            - mysql
+
+volumes:
+    mysql: ~
+
+networks:
+    bot: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         environment:
           - MYSQL_ROOT_PASSWORD=MYSQL_ROOT_PASSWORD
         volumes:
-            - mysql:/data/db
+            - mysql:/var/lib/mysql
 
     bot:
         build: .


### PR DESCRIPTION
**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [ ] This includes minor changes (minimal usage changes, minor new features)
- [ ] This includes patches (bug fixes)
- [x] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

Not that I found.

**Changes made**

Changed `Dockerfile` to properly use a stable node buster image as well as correctly setting the `NODE_ENV` variable to `production`. We also downgrade permissions with `USER node` to ensure that no file is being ran by `root`. Both of these changes are done to further optimize production builds.

We also remove the `COPY . .` in favor of copying directories since most of the repo is cluttered with stuff that isn't needed in a production bot. Environment variables should be set via command line or via `--env-file .env` flag, and we don't need any of the repo-specific `.yml` files. This should help reduce overall size of the image, going from `958.89 MB` to `218.3 MB` with a fresh repo:

![image](https://user-images.githubusercontent.com/55610086/131416210-a53bb2b6-8efe-4dad-ad5a-b9abdb70b836.png)

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [ ] I have updated related documentation (if necessary)
- [x] My changes use consistent code style
- [x] My changes have been tested and confirmed to work


I am a bit uneasy on the change with the `node:16.6.1-buster-slim` choice as it could in theory break some bots (not having `curl` as an example) and therefore should probably be discussed, but I think the reduction in image size greatly makes up for this.

Fixed commit history :) (I should learn how to use git better :/)