### PR TITLE
feat(channels): DM user on closing a ticket Fixes 338

### DIFF
--- a/src/commands/close.js
+++ b/src/commands/close.js
@@ -284,6 +284,9 @@ module.exports = class CloseCommand extends Command {
 						],
 						ephemeral: true
 					});
+					await this.client.users.fetch(interaction.user.id).then((user) => {
+						user.send(`Your ticket '${interaction.channel.name}' has been deleted.`);
+					});
 				} else {
 					await i.editReply({
 						components: [],

--- a/src/index.js
+++ b/src/index.js
@@ -212,6 +212,25 @@ class Bot extends Client {
 		}
 	}
 
+	async timerFunction() {
+		let ms = 10000;
+		setInterval(async () => {
+			console.log("Ticket Bot");
+			const res = await this.db.query('SELECT * FROM dsctickets_tickets where last_message > (NOW() + INTERVAL 1 DAY)');
+			if(res[0].length > 0) {
+				res[0].forEach(async (result) => {
+					const curr = this.channels.cache.get(result.id);
+					if(curr) {
+						this.tickets.close(result.id, this.user.id, result.guild, "");
+						await this.users.fetch(result.creator).then((user) => {
+							user.send(`Your ticket has been deleted.`);
+						})
+					}
+				})
+			}
+		}, ms);
+	}
+
 }
 
 new Bot();


### PR DESCRIPTION
<!--
	Thank you for contributing to Discord Tickets.
	If you haven't already, please read the CONTRIBUTING guidelines (https://github.com/discord-tickets/.github/blob/main/CONTRIBUTING.md) before creating a pull request.
	Unless this pull request is for something minor like a fixing a typo, you should create an issue first.
-->

**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [ ] This includes minor changes (minimal usage changes, minor new features)
- [ ] This includes patches (bug fixes)
- [ ] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

This fix is related to #338 

<!-- Reference any issues here -->

**Changes made**

Fetch function to automatically sends a DM message to the user after their ticket is closed.

<!-- Describe your changes -->

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [ ] I have updated related documentation (if necessary)
- [ ] My changes use consistent code style
- [ ] My changes have been tested and confirmed to work
