### PR TITLE
feat(channels): auto close ticket after 24hrs of inactivity Fixes 299

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -212,6 +212,25 @@ class Bot extends Client {
 		}
 	}
 
+	async timerFunction() {
+		let ms = 10000;
+		setInterval(async () => {
+			console.log("Ticket Bot");
+			const res = await this.db.query('SELECT * FROM dsctickets_tickets where last_message > (NOW() + INTERVAL 1 DAY)');
+			if(res[0].length > 0) {
+				res[0].forEach(async (result) => {
+					const curr = this.channels.cache.get(result.id);
+					if(curr) {
+						this.tickets.close(result.id, this.user.id, result.guild, "");
+						await this.users.fetch(result.creator).then((user) => {
+							user.send(`Your ticket has been deleted.`);
+						})
+					}
+				})
+			}
+		}, ms);
+	}
+
 }
 
 new Bot();


### PR DESCRIPTION
<!--
	Thank you for contributing to Discord Tickets.
	If you haven't already, please read the CONTRIBUTING guidelines (https://github.com/discord-tickets/.github/blob/main/CONTRIBUTING.md) before creating a pull request.
	Unless this pull request is for something minor like a fixing a typo, you should create an issue first.
-->

**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [ ] This includes minor changes (minimal usage changes, minor new features)
- [ ] This includes patches (bug fixes)
- [ ] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

This fix is related to #299 

<!-- Reference any issues here -->

**Changes made**

Function which checks for inactivity in ticket channels and delete it after 24hrs.

<!-- Describe your changes -->

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [ ] I have updated related documentation (if necessary)
- [ ] My changes use consistent code style
- [ ] My changes have been tested and confirmed to work
