### PR TITLE
fix: use category name and emoji when only one category is selected

### DIFF
--- a/src/routes/api/admin/guilds/[guild]/panels.js
+++ b/src/routes/api/admin/guilds/[guild]/panels.js
@@ -2,7 +2,6 @@ const {
 	ActionRowBuilder,
 	ButtonBuilder,
 	ButtonStyle: {
-		Primary,
 		Secondary,
 	},
 	ChannelType: { GuildText },

--- a/src/routes/api/admin/guilds/[guild]/panels.js
+++ b/src/routes/api/admin/guilds/[guild]/panels.js
@@ -83,9 +83,9 @@ module.exports.post = fastify => ({
 							action: 'create',
 							target: categories[0].id,
 						}))
-						.setStyle(Primary)
-						.setLabel(getMessage('buttons.create.text'))
-						.setEmoji(getMessage('buttons.create.emoji')),
+						.setStyle(Secondary)
+						.setLabel(categories[0].name)
+						.setEmoji(emoji.hasEmoji(categories[0].emoji) ? emoji.get(categories[0].emoji) : { id: categories[0].emoji }),
 				);
 			} else if (data.type === 'BUTTON') {
 				components.push(


### PR DESCRIPTION
fix: use category name and emoji when only one category is selected

<!--
	Thank you for contributing to Discord Tickets.
	If you haven't already, please read the CONTRIBUTING guidelines (https://github.com/discord-tickets/.github/blob/main/CONTRIBUTING.md) before creating a pull request.
	Unless this pull request is for something minor like a fixing a typo, you should create an issue first.
-->

**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [X] This includes minor changes (minimal usage changes, minor new features)
- [X] This includes patches (bug fixes)
- [X] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

<!-- Reference any issues here -->

Related issue: #450 

**Changes made**

I changed the behavior of creating a new panel.
It now use the category name and emoji if only one Category is selected.
I changed the style by the Secondary style like if we choose multiple categories.

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- I have updated related documentation (if necessary)
- My changes use consistent code style
- My changes have been tested and confirmed to work
