### PR TITLE
fix: fix open tickets count

### DIFF
--- a/src/listeners/client/ready.js
+++ b/src/listeners/client/ready.js
@@ -65,10 +65,11 @@ module.exports = class extends Listener {
 						firstResponseAt: true,
 					},
 				});
-				const closedTickets = tickets.filter(t => t.firstResponseAt && t.closedAt);
+				const closedTicketsWithResponse = tickets.filter(t => t.firstResponseAt && t.closedAt);
+				const closedTickets = tickets.filter(t => t.closedAt);
 				cached = {
-					avgResolutionTime: ms(getAvgResolutionTime(closedTickets)),
-					avgResponseTime: ms(getAvgResponseTime(closedTickets)),
+					avgResolutionTime: ms(getAvgResolutionTime(closedTicketsWithResponse)),
+					avgResponseTime: ms(getAvgResponseTime(closedTicketsWithResponse)),
 					openTickets: tickets.length - closedTickets.length,
 					totalTickets: tickets.length,
 				};


### PR DESCRIPTION
<!--
	Thank you for contributing to Discord Tickets.
	If you haven't already, please read the CONTRIBUTING guidelines (https://github.com/discord-tickets/.github/blob/main/CONTRIBUTING.md) before creating a pull request.
	Unless this pull request is for something minor like a fixing a typo, you should create an issue first.
-->

**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [ ] This includes minor changes (minimal usage changes, minor new features)
- [X] This includes patches (bug fixes)
- [ ] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

Fixes #499 

**Changes made**

In the `ready` client listener, renamed the pre-existing `closedTickets` variable to `closedTicketsWithResponse`. Alongside this variable, added a new one with the previous name of `closedTickets`. This new variable filters tickets by `ticket.closedAt`, instead of `ticket.firstResponseAt && ticket.closedAt`.
This allows the placeholder `{openTickets}` in the bot's presence to display accurate information.

**Confirmations**

- [ ] I have updated related documentation (if necessary)
- [X] My changes use consistent code style
- [X] My changes have been tested and confirmed to work
