### PR TITLE
fix: fix activity name update

### DIFF
--- a/src/listeners/client/ready.js
+++ b/src/listeners/client/ready.js
@@ -75,7 +75,7 @@ module.exports = class extends Listener {
 				};
 				await client.keyv.set(cacheKey, cached, ms('15m'));
 			}
-			const activity = client.config.presence.activities[next];
+			const activity = { ...client.config.presence.activities[next] };
 			activity.name = activity.name
 				.replace(/{+avgResolutionTime}+/gi, cached.avgResolutionTime)
 				.replace(/{+avgResponseTime}+/gi, cached.avgResponseTime)


### PR DESCRIPTION
<!--
	Thank you for contributing to Discord Tickets.
	If you haven't already, please read the CONTRIBUTING guidelines (https://github.com/discord-tickets/.github/blob/main/CONTRIBUTING.md) before creating a pull request.
	Unless this pull request is for something minor like a fixing a typo, you should create an issue first.
-->

**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [ ] This includes minor changes (minimal usage changes, minor new features)
- [X] This includes patches (bug fixes)
- [ ] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

No.

**Changes made**

In the `client/ready.js` listener, the `activities` object was being referenced instead of copied. This caused the activities' names to be set on bot startup, and they would not change even after the 15 minutes cache TTL expired.
I have changed it to create a shallow copy of the `client.config.presence.activities[next]` object using the spread operator, instead of making a reference to the original object.

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [ ] I have updated related documentation (if necessary)
- [X] My changes use consistent code style
- [X] My changes have been tested and confirmed to work
