### PR TITLE
Fix wrong docker permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ RUN apk --no-cache add curl \
 	&& adduser --disabled-password --home /home/container container \
 	&& mkdir /app \
 	&& chown container:container /app \
-	&& chmod -R 777 /app \
-	&& chown -R container:container /home/container
+	&& chmod -R 777 /app
 USER container
 ENV USER=container \
 	HOME=/home/container \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apk --no-cache add curl \
 	&& adduser --disabled-password --home /home/container container \
 	&& mkdir /app \
 	&& chown container:container /app \
-	&& chmod -R 777 /app
+	&& chmod -R 777 /app \
+	&& chown -R container:container /home/container
 USER container
 ENV USER=container \
 	HOME=/home/container \

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -6,6 +6,7 @@ if [ "$PTERODACTYL" = "true" ]; then
     base_dir="/home/container/app"
 elif [ "$DOCKER" = "true" ]; then
     base_dir="/app"
+    chown -R container:container /home/container
 else
     source="${BASH_SOURCE}"
     base_dir=$(dirname $(dirname "$source"))


### PR DESCRIPTION
<!--
	Thank you for contributing to Discord Tickets.
	If you haven't already, please read the CONTRIBUTING guidelines (https://github.com/discord-tickets/.github/blob/main/CONTRIBUTING.md) before creating a pull request.
	Unless this pull request is for something minor like a fixing a typo, you should create an issue first.
-->

**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [ ] This includes minor changes (minimal usage changes, minor new features)
- [X] This includes patches (bug fixes)
- [ ] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

There is an Docker error which causes that when using your docker-compose file which mounts volume in /home/container/user there are a default permissions (root:root). Because of that this is not possible to normally start bot using your dockerfile because of permission denied error and you have to manually change /home/container/user directory to container:container permissions.

**Changes made**

I changed a bit start script in scripts/start.sh to let them automatically recursive chown whole /home/container directory into container:container permissions to avoid situation where volume on /home/container/user is root:root and causing permission denied errors.

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [ ] I have updated related documentation (if necessary)
- [X] My changes use consistent code style
- [X] My changes have been tested and confirmed to work
