### PR TITLE
feat: save avatars locally

### DIFF
--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -70,3 +70,37 @@ module.exports.getPrivilegeLevel = async member => {
 	else if (await this.isStaff(member.guild, member.id)) return 1;
 	else return 0;
 };
+
+/**
+ *
+ * @param {import("discord.js").GuildMember} member
+ * @returns {{hash: string, url: string} | false}
+ */
+module.exports.getAvatarData = member => {
+	if (!member?.user) return false;
+
+	const cdnBaseUrl = 'https://cdn.discordapp.com';
+
+	const {
+		id: userId,
+		avatar: userAvatar,
+	} = member.user;
+	const { id: guildId } = member.guild;
+	const memberAvatar = member.avatar;
+
+	const avatarHash = memberAvatar || userAvatar;
+	if (!avatarHash) return false;
+
+	const isAnimated = avatarHash.startsWith('a_');
+	const ext = isAnimated ? '.gif' : '.png';
+
+	const url = memberAvatar
+		? `${cdnBaseUrl}/guilds/${guildId}/users/${userId}/avatars/${avatarHash}${ext}`
+		: `${cdnBaseUrl}/avatars/${userId}/${avatarHash}${ext}`;
+
+	return {
+		hash: avatarHash,
+		isAnimated,
+		url,
+	};
+};

--- a/src/lib/workers/users.js
+++ b/src/lib/workers/users.js
@@ -1,0 +1,38 @@
+const { expose } = require('threads/worker');
+const fs = require('fs').promises;
+const path = require('path');
+
+expose({
+	async saveAvatar(avatar) {
+		const avatarDir = path.join('user', 'avatars');
+
+		const ext = path.extname(avatar.url);
+		const filename = `${avatar.hash}${ext}`;
+		const filePath = path.join(avatarDir, filename);
+
+		try {
+			await fs.access(filePath);
+			return filename; // Avatar already saved
+		  } catch (err) {
+			if (err.code !== 'ENOENT') {
+			  return false;
+			}
+		  }
+
+		const res = await fetch(avatar.url);
+		if (!res.ok) {
+		  return false;
+		}
+
+		const arrayBuffer = await res.arrayBuffer();
+		const buffer = Buffer.from(arrayBuffer);
+
+		try {
+			await fs.writeFile(filePath, buffer);
+		} catch {
+			return false;
+		}
+
+		return filename;
+	},
+});


### PR DESCRIPTION
<!--
	Thank you for contributing to Discord Tickets.
	If you haven't already, please read the CONTRIBUTING guidelines (https://github.com/discord-tickets/.github/blob/main/CONTRIBUTING.md) before creating a pull request.
	Unless this pull request is for something minor like a fixing a typo, you should create an issue first.
-->

**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [x] This includes minor changes (minimal usage changes, minor new features)
- [ ] This includes patches (bug fixes)
- [ ] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

Mentioned in: #336 

**Changes made**

- Added users worker, for handling avatar downloads (`src/lib/workers/users.js`)
- Added getAvatarData() method for returning the correct server/global avatar hash along with CDN-URL to `src/lib/users.js`
- Modified `src/lib/tickets/archiver.js` to use save avatar and use new `getAvatarData()` 

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [x] I have updated related documentation (if necessary)
- [x] My changes use consistent code style
- [x] My changes have been tested and confirmed to work
