### PR TITLE
fix(docker): pre-create runtime directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ RUN mkdir /app \
 	&& chown container:container /app \
 	&& chmod -R 777 /app
 
+RUN mkdir -p /home/container/user /home/container/logs \
+    && chown -R container:container /home/container
+
 USER container
 ENV USER=container \
 	HOME=/home/container \


### PR DESCRIPTION
## Summary
This pull request addresses issue #521 and #588 by ensuring that runtime directories are pre-created with the correct ownership and permissions during the **image build process**. This change prevents `EACCES` errors that occur when [Docker automatically creates these directories](https://docs.docker.com/engine/storage/volumes), leading to permission mismatches for the rootless user ("_container:container_") running the application.

---

- Added creation of runtime directories (`/container/user` and `/container/logs`) in the Dockerfile.
- Ensures these directories are created with appropriate permissions during image build.
- Prevents Docker from auto-creating these directories with root ownership at runtime, avoiding access issues.

---

**Versioning information**
- [ ] This includes major changes (breaking changes)
- [ ] This includes minor changes (minimal usage changes, minor new features)
- [x] This includes patches (bug fixes)
- [ ] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

Closes #588 
Closes #521 

**Changes made**

Addition to Dockerfile:
```dockerfile
RUN mkdir -p /home/container/user /home/container/logs \
&& chown -R container:container /home/container
``` 

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [ ] I have updated related documentation (if necessary)
- [x] My changes use consistent code style
- [x] My changes have been tested and confirmed to work
