### PR TITLE
feat: block timed out users

### DIFF
--- a/src/lib/tickets/manager.js
+++ b/src/lib/tickets/manager.js
@@ -226,6 +226,11 @@ module.exports = class TicketManager {
 			if (blocked) return await sendError('blocked');
 		}
 
+		// Don't let timed out users open tickets, they won't be able to write anything inside
+		if (member.isCommunicationDisabled()) {
+			return await sendError('blocked');
+		}
+
 		if (category.requiredRoles.length !== 0) {
 			const missing = category.requiredRoles.some(r => !member.roles.cache.has(r));
 			if (missing) return await sendError('missing_roles');


### PR DESCRIPTION
Don't let timed out users open tickets. Letting them open tickets is useless as they won't be able to write anything inside. This reduces potential spam from misbehaving users.

**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [x] This includes minor changes (minimal usage changes, minor new features)
- [ ] This includes patches (bug fixes)
- [ ] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

No

**Changes made**

Users that are not allowed to communicate due to a timeout are no longer able to open tickets.

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [x] I have updated related documentation (if necessary)
- [x] My changes use consistent code style
- [ ] My changes have been tested and confirmed to work

**THIS IS UNTESTED**
