### PR TITLE
fix(api/panels): use the category label and emoji even if its only a single button

### DIFF
--- a/src/routes/api/admin/guilds/[guild]/panels.js
+++ b/src/routes/api/admin/guilds/[guild]/panels.js
@@ -82,15 +82,16 @@ module.exports.post = fastify => ({
 			const components = [];
 
 			if (categories.length === 1) {
+				let category = categories[0];
 				components.push(
 					new ButtonBuilder()
 						.setCustomId(JSON.stringify({
 							action: 'create',
-							target: categories[0].id,
+							target: category.id,
 						}))
 						.setStyle(Primary)
-						.setLabel(getMessage('buttons.create.text'))
-						.setEmoji(getMessage('buttons.create.emoji')),
+						.setLabel(category.name)
+						.setEmoji(emoji.hasEmoji(category.emoji) ? emoji.get(category.emoji) : { id: category.emoji }),
 				);
 			} else if (data.type === 'BUTTON') {
 				components.push(


### PR DESCRIPTION
**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [X] This includes minor changes (minimal usage changes, minor new features)
- [ ] This includes patches (bug fixes)
- [ ] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

https://github.com/discord-tickets/bot/issues/616

**Changes made**

Chnaged that panel creation so that panles with a single category also refelect that categorys title in the button.


**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [ ] I have updated related documentation (if necessary)
- [X ] My changes use consistent code style
- [ ] My changes have been tested and confirmed to work
