### PR TITLE
refactor: use ephemeral interaction response flag

### DIFF
--- a/src/buttons/close.js
+++ b/src/buttons/close.js
@@ -1,6 +1,7 @@
 const { Button } = require('@eartharoid/dbf');
 const ExtendedEmbedBuilder = require('../lib/embed');
 const { isStaff } = require('../lib/users');
+const { MessageFlags } = require('discord.js');
 
 module.exports = class CloseButton extends Button {
 	constructor(client, options) {
@@ -33,7 +34,7 @@ module.exports = class CloseButton extends Button {
 							.setColor(ticket.guild.errorColour)
 							.setDescription(getMessage('ticket.close.wait_for_staff')),
 					],
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral,
 				});
 			} else if (id.expect === 'user' && interaction.user.id !== ticket.createdById) {
 				return await interaction.reply({
@@ -42,7 +43,7 @@ module.exports = class CloseButton extends Button {
 							.setColor(ticket.guild.errorColour)
 							.setDescription(getMessage('ticket.close.wait_for_user')),
 					],
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral,
 				});
 			} else {
 				if (id.accepted) {

--- a/src/commands/message/pin.js
+++ b/src/commands/message/pin.js
@@ -1,5 +1,6 @@
 const { MessageCommand } = require('@eartharoid/dbf');
 const ExtendedEmbedBuilder = require('../../lib/embed');
+const { MessageFlags } = require('discord.js');
 
 module.exports = class PinMessageCommand extends MessageCommand {
 	constructor(client, options) {
@@ -21,7 +22,7 @@ module.exports = class PinMessageCommand extends MessageCommand {
 		/** @type {import("client")} */
 		const client = this.client;
 
-		await interaction.deferReply({ ephemeral: true });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 		const ticket = await client.prisma.ticket.findUnique({
 			include: { guild: true },
 			where: { id: interaction.channel.id },

--- a/src/commands/slash/add.js
+++ b/src/commands/slash/add.js
@@ -1,5 +1,7 @@
 const { SlashCommand } = require('@eartharoid/dbf');
-const { ApplicationCommandOptionType } = require('discord.js');
+const {
+	ApplicationCommandOptionType, MessageFlags,
+} = require('discord.js');
 const ExtendedEmbedBuilder = require('../../lib/embed');
 const { isStaff } = require('../../lib/users');
 const { logTicketEvent } = require('../../lib/logging');
@@ -42,7 +44,7 @@ module.exports = class AddSlashCommand extends SlashCommand {
 		/** @type {import("client")} */
 		const client = this.client;
 
-		await interaction.deferReply({ ephemeral: true });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
 		const ticket = await client.prisma.ticket.findUnique({
 			include: { guild: true },

--- a/src/commands/slash/force-close.js
+++ b/src/commands/slash/force-close.js
@@ -5,6 +5,7 @@ const {
 	ButtonBuilder,
 	ButtonStyle,
 	ComponentType,
+	MessageFlags,
 } = require('discord.js');
 const ExtendedEmbedBuilder = require('../../lib/embed');
 const { isStaff } = require('../../lib/users');
@@ -59,7 +60,7 @@ module.exports = class ForceCloseSlashCommand extends SlashCommand {
 		/** @type {import("client")} */
 		const client = this.client;
 
-		await interaction.deferReply({ ephemeral: true });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
 		const settings = await client.prisma.guild.findUnique({ where: { id: interaction.guild.id } });
 		const getMessage = client.i18n.getLocale(settings.locale);
@@ -215,7 +216,7 @@ module.exports = class ForceCloseSlashCommand extends SlashCommand {
 									.setTitle(getMessage('commands.slash.force-close.confirmed_multiple.title', tickets.length, tickets.length))
 									.setDescription(getMessage('commands.slash.force-close.confirmed_multiple.description')),
 							],
-							ephemeral: true,
+							flags: MessageFlags.Ephemeral,
 						});
 						setTimeout(async () => {
 							for (const ticket of tickets) {

--- a/src/commands/slash/help.js
+++ b/src/commands/slash/help.js
@@ -2,6 +2,7 @@ const { SlashCommand } = require('@eartharoid/dbf');
 const { isStaff } = require('../../lib/users');
 const ExtendedEmbedBuilder = require('../../lib/embed');
 const { version } = require('../../../package.json');
+const { MessageFlags } = require('discord.js');
 
 module.exports = class ClaimSlashCommand extends SlashCommand {
 	constructor(client, options) {
@@ -23,7 +24,7 @@ module.exports = class ClaimSlashCommand extends SlashCommand {
 		/** @type {import("client")} */
 		const client = this.client;
 
-		await interaction.deferReply({ ephemeral: true });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 		const staff = await isStaff(interaction.guild, interaction.member.id);
 		const settings = await client.prisma.guild.findUnique({ where: { id: interaction.guild.id } });
 		const getMessage = client.i18n.getLocale(settings.locale);

--- a/src/commands/slash/move.js
+++ b/src/commands/slash/move.js
@@ -1,5 +1,7 @@
 const { SlashCommand } = require('@eartharoid/dbf');
-const { ApplicationCommandOptionType } = require('discord.js');
+const {
+	ApplicationCommandOptionType, MessageFlags,
+} = require('discord.js');
 const ExtendedEmbedBuilder = require('../../lib/embed');
 const { isStaff } = require('../../lib/users');
 const { getEmoji } = require('./priority');
@@ -36,7 +38,7 @@ module.exports = class MoveSlashCommand extends SlashCommand {
 		/** @type {import("client")} */
 		const client = this.client;
 
-		await interaction.deferReply({ ephemeral: false });
+		await interaction.deferReply();
 
 		const ticket = await client.prisma.ticket.findUnique({
 			include: {
@@ -59,7 +61,7 @@ module.exports = class MoveSlashCommand extends SlashCommand {
 						.setTitle(getMessage('misc.not_ticket.title'))
 						.setDescription(getMessage('misc.not_ticket.description')),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 
@@ -94,7 +96,7 @@ module.exports = class MoveSlashCommand extends SlashCommand {
 						.setTitle(getMessage('misc.category_full.title'))
 						.setDescription(getMessage('misc.category_full.description')),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		} else {
 			// don't reassign `ticket`, the previous value is used below

--- a/src/commands/slash/remove.js
+++ b/src/commands/slash/remove.js
@@ -1,5 +1,7 @@
 const { SlashCommand } = require('@eartharoid/dbf');
-const { ApplicationCommandOptionType } = require('discord.js');
+const {
+	ApplicationCommandOptionType, MessageFlags,
+} = require('discord.js');
 const ExtendedEmbedBuilder = require('../../lib/embed');
 const { isStaff } = require('../../lib/users');
 const { logTicketEvent } = require('../../lib/logging');
@@ -42,7 +44,7 @@ module.exports = class RemoveSlashCommand extends SlashCommand {
 		/** @type {import("client")} */
 		const client = this.client;
 
-		await interaction.deferReply({ ephemeral: true });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
 		const ticket = await client.prisma.ticket.findUnique({
 			include: { guild: true },

--- a/src/commands/slash/rename.js
+++ b/src/commands/slash/rename.js
@@ -126,7 +126,7 @@ module.exports = class RenameSlashCommand extends SlashCommand {
 						.setTitle(getMessage('commands.slash.rename.ratelimited.title'))
 						.setDescription(getMessage('commands.slash.rename.ratelimited.description')),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 

--- a/src/commands/slash/tag.js
+++ b/src/commands/slash/tag.js
@@ -1,5 +1,7 @@
 const { SlashCommand } = require('@eartharoid/dbf');
-const { ApplicationCommandOptionType } = require('discord.js');
+const {
+	ApplicationCommandOptionType, MessageFlags,
+} = require('discord.js');
 const ExtendedEmbedBuilder = require('../../lib/embed');
 
 module.exports = class TagSlashCommand extends SlashCommand {
@@ -41,7 +43,7 @@ module.exports = class TagSlashCommand extends SlashCommand {
 		const client = this.client;
 
 		const user = interaction.options.getUser('for', false);
-		await interaction.deferReply({ ephemeral: !user });
+		await interaction.deferReply({ flags: user ? 0 : MessageFlags.Ephemeral });
 		const tag = await client.prisma.tag.findUnique({
 			include: { guild: true },
 			where: { id: interaction.options.getInteger('tag', true) },

--- a/src/commands/slash/tickets.js
+++ b/src/commands/slash/tickets.js
@@ -2,6 +2,7 @@ const { SlashCommand } = require('@eartharoid/dbf');
 const {
 	ApplicationCommandOptionType,
 	PermissionsBitField,
+	MessageFlags,
 } = require('discord.js');
 const { isStaff } = require('../../lib/users');
 const ExtendedEmbedBuilder = require('../../lib/embed');
@@ -39,7 +40,7 @@ module.exports = class TicketsSlashCommand extends SlashCommand {
 		/** @type {import("client")} */
 		const client = this.client;
 
-		await interaction.deferReply({ ephemeral: true });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 		await client.application.commands.fetch();
 
 		const member = interaction.options.getMember('member', false) ?? interaction.member;

--- a/src/commands/slash/topic.js
+++ b/src/commands/slash/topic.js
@@ -4,6 +4,7 @@ const {
 	ModalBuilder,
 	TextInputBuilder,
 	TextInputStyle,
+	MessageFlags,
 } = require('discord.js');
 const ExtendedEmbedBuilder = require('../../lib/embed');
 const { quick } = require('../../lib/threads');
@@ -51,7 +52,7 @@ module.exports = class TopicSlashCommand extends SlashCommand {
 						.setTitle(getMessage('misc.not_ticket.title'))
 						.setDescription(getMessage('misc.not_ticket.description')),
 				],
-				flags: 'Ephemeral',
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 

--- a/src/commands/slash/transcript.js
+++ b/src/commands/slash/transcript.js
@@ -2,6 +2,7 @@ const { SlashCommand } = require('@eartharoid/dbf');
 const {
 	ApplicationCommandOptionType,
 	PermissionsBitField,
+	MessageFlags,
 } = require('discord.js');
 const fs = require('fs');
 const { join } = require('path');
@@ -113,7 +114,7 @@ module.exports = class TranscriptSlashCommand extends SlashCommand {
 		/** @type {import("client")} */
 		const client = this.client;
 
-		await interaction.deferReply({ ephemeral: true });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 		ticketId = ticketId || interaction.options.getString('ticket', true);
 		const ticket = await client.prisma.ticket.findUnique({
 			include: {

--- a/src/commands/slash/transfer.js
+++ b/src/commands/slash/transfer.js
@@ -39,7 +39,7 @@ module.exports = class TransferSlashCommand extends SlashCommand {
 		/** @type {import("client")} */
 		const client = this.client;
 
-		await interaction.deferReply({ ephemeral: false });
+		await interaction.deferReply();
 
 		const member = interaction.options.getMember('member', true);
 

--- a/src/commands/user/create.js
+++ b/src/commands/user/create.js
@@ -9,6 +9,7 @@ const {
 	ComponentType,
 	StringSelectMenuBuilder,
 	StringSelectMenuOptionBuilder,
+	MessageFlags,
 } = require('discord.js');
 const emoji = require('node-emoji');
 
@@ -32,7 +33,7 @@ module.exports = class CreateUserCommand extends UserCommand {
 		/** @type {import("client")} */
 		const client = this.client;
 
-		await interaction.deferReply({ flags: 'Ephemeral' });
+		await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
 		const settings = await client.prisma.guild.findUnique({
 			include: { categories: true },

--- a/src/lib/tickets/manager.js
+++ b/src/lib/tickets/manager.js
@@ -11,6 +11,7 @@ const {
 	StringSelectMenuOptionBuilder,
 	TextInputBuilder,
 	TextInputStyle,
+	MessageFlags,
 } = require('discord.js');
 const emoji = require('node-emoji');
 const ms = require('ms');
@@ -180,7 +181,7 @@ module.exports = class TicketManager {
 						.setTitle(getMessage('misc.unknown_category.title'))
 						.setDescription(getMessage('misc.unknown_category.description')),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 
@@ -202,7 +203,7 @@ module.exports = class TicketManager {
 						.setTitle(getMessage('misc.ratelimited.title'))
 						.setDescription(getMessage('misc.ratelimited.description')),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		} else {
 			this.client.keyv.set(rlKey, true, ms('5s'));
@@ -218,7 +219,7 @@ module.exports = class TicketManager {
 					.setTitle(getMessage(`misc.${name}.title`))
 					.setDescription(getMessage(`misc.${name}.description`)),
 			],
-			ephemeral: true,
+			flags: MessageFlags.Ephemeral,
 		});
 
 		if (category.guild.blocklist.length !== 0) {
@@ -254,7 +255,7 @@ module.exports = class TicketManager {
 						.setTitle(getMessage('misc.member_limit.title', memberCount, memberCount))
 						.setDescription(getMessage('misc.member_limit.description', memberCount)),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 
@@ -270,7 +271,7 @@ module.exports = class TicketManager {
 						.setTitle(getMessage('misc.cooldown.title'))
 						.setDescription(getMessage('misc.cooldown.description', { time: ms(cooldown - Date.now()) })),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 
@@ -369,7 +370,7 @@ module.exports = class TicketManager {
 		action, categoryId, interaction, topic, referencesMessageId, referencesTicketId,
 	}) {
 		const [, category] = await Promise.all([
-			interaction.deferReply({ ephemeral: true }),
+			interaction.deferReply({ flags: MessageFlags.Ephemeral }),
 			this.getCategory(categoryId),
 		]);
 
@@ -835,11 +836,11 @@ module.exports = class TicketManager {
 						.setTitle(getMessage('commands.slash.claim.not_staff.title'))
 						.setDescription(getMessage('commands.slash.claim.not_staff.description')),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 
-		await interaction.deferReply({ ephemeral: false });
+		await interaction.deferReply();
 
 		await Promise.all([
 			interaction.channel.permissionOverwrites.edit(interaction.user, { 'ViewChannel': true }, `Ticket claimed by ${interaction.user.tag}`),
@@ -938,11 +939,11 @@ module.exports = class TicketManager {
 						.setTitle(getMessage('commands.slash.claim.not_staff.title'))
 						.setDescription(getMessage('commands.slash.claim.not_staff.description')),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 
-		await interaction.deferReply({ ephemeral: false });
+		await interaction.deferReply();
 
 		await Promise.all([
 			interaction.channel.permissionOverwrites.delete(interaction.user, `Ticket released by ${interaction.user.tag}`),
@@ -1050,7 +1051,7 @@ module.exports = class TicketManager {
 	async beforeRequestClose(interaction) {
 		const ticket = await this.getTicket(interaction.channel.id);
 		if (!ticket) {
-			await interaction.deferReply({ ephemeral: true });
+			await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 			const {
 				errorColour,
 				footer,

--- a/src/lib/tickets/utils.js
+++ b/src/lib/tickets/utils.js
@@ -3,6 +3,7 @@ const {
 	EmbedBuilder,
 	StringSelectMenuBuilder,
 	StringSelectMenuOptionBuilder,
+	MessageFlags,
 } = require('discord.js');
 const emoji = require('node-emoji');
 
@@ -35,7 +36,7 @@ module.exports = {
 						.setTitle(getMessage('misc.no_categories.title'))
 						.setDescription(getMessage('misc.no_categories.description', { url: `${process.env.HTTP_EXTERNAL}/settings/${interaction.guildId}` })),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		} else if (settings.categories.length === 1) {
 			await client.tickets.create({
@@ -69,7 +70,7 @@ module.exports = {
 								),
 						),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 	},

--- a/src/listeners/client/messageDelete.js
+++ b/src/listeners/client/messageDelete.js
@@ -1,5 +1,7 @@
 const { Listener } = require('@eartharoid/dbf');
-const { AuditLogEvent } = require('discord.js');
+const {
+	AuditLogEvent, MessageFlags,
+} = require('discord.js');
 const { logMessageEvent } = require('../../lib/logging');
 const { quick } = require('../../lib/threads');
 
@@ -73,7 +75,7 @@ module.exports = class extends Listener {
 			}
 		}
 
-		if (message.author.id !== client.user.id && !message.flags.has('Ephemeral')) {
+		if (message.author.id !== client.user.id && !message.flags.has(MessageFlags.Ephemeral)) {
 			await logMessageEvent(this.client, {
 				action: 'delete',
 				diff: {

--- a/src/listeners/client/messageUpdate.js
+++ b/src/listeners/client/messageUpdate.js
@@ -1,5 +1,5 @@
 const { Listener } = require('@eartharoid/dbf');
-const { MessageFlagsBitField } = require('discord.js');
+const { MessageFlags } = require('discord.js');
 const { logMessageEvent } = require('../../lib/logging');
 
 module.exports = class extends Listener {
@@ -29,7 +29,7 @@ module.exports = class extends Listener {
 		}
 
 		if (!newMessage.guild) return;
-		if (newMessage.flags.has(MessageFlagsBitField.Flags.Ephemeral)) return;
+		if (newMessage.flags.has(MessageFlags.Ephemeral)) return;
 		if (!newMessage.editedAt) return;
 
 		const ticket = await client.prisma.ticket.findUnique({

--- a/src/modals/feedback.js
+++ b/src/modals/feedback.js
@@ -1,6 +1,7 @@
 const { Modal } = require('@eartharoid/dbf');
 const ExtendedEmbedBuilder = require('../lib/embed');
 const { quick } = require('../lib/threads');
+const { MessageFlags } = require('discord.js');
 
 module.exports = class FeedbackModal extends Modal {
 	constructor(client, options) {
@@ -60,7 +61,7 @@ module.exports = class FeedbackModal extends Modal {
 						.setColor(ticket.guild.primaryColour)
 						.setDescription(getMessage('ticket.feedback')),
 				],
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 	}

--- a/src/modals/questions.js
+++ b/src/modals/questions.js
@@ -1,5 +1,7 @@
 const { Modal } = require('@eartharoid/dbf');
-const { EmbedBuilder } = require('discord.js');
+const {
+	EmbedBuilder, MessageFlags,
+} = require('discord.js');
 const ExtendedEmbedBuilder = require('../lib/embed');
 const { logTicketEvent } = require('../lib/logging');
 const { reusable } = require('../lib/threads');
@@ -26,7 +28,7 @@ module.exports = class QuestionsModal extends Modal {
 		if (id.edit) {
 			const worker = await reusable('crypto');
 			try {
-				await interaction.deferReply({ ephemeral: true });
+				await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
 				const { category } = await client.prisma.ticket.findUnique({
 					select: { category: { select: { customTopic: true } } },

--- a/src/modals/topic.js
+++ b/src/modals/topic.js
@@ -1,5 +1,7 @@
 const { Modal } = require('@eartharoid/dbf');
-const { EmbedBuilder } = require('discord.js');
+const {
+	EmbedBuilder, MessageFlags,
+} = require('discord.js');
 const ExtendedEmbedBuilder = require('../lib/embed');
 const { logTicketEvent } = require('../lib/logging');
 const { reusable } = require('../lib/threads');
@@ -19,7 +21,7 @@ module.exports = class TopicModal extends Modal {
 		if (id.edit) {
 			const worker = await reusable('crypto');
 			try {
-				await interaction.deferReply({ ephemeral: true });
+				await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 				const topic = interaction.fields.getTextInputValue('topic');
 				const select = {
 					createdById: true,


### PR DESCRIPTION
`ephemeral` boolean  interaction response options have been deprecated
As seen in console warnings
```
[WARN] Warning: Supplying "ephemeral" for interaction response options is deprecated. Utilize flags instead.
```

<!--
	Thank you for contributing to Discord Tickets.
	If you haven't already, please read the CONTRIBUTING guidelines (https://github.com/discord-tickets/.github/blob/main/CONTRIBUTING.md) before creating a pull request.
	Unless this pull request is for something minor like a fixing a typo, you should create an issue first.
-->

**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [ ] This includes minor changes (minimal usage changes, minor new features)
- [ ] This includes patches (bug fixes)
- [x] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

None found

**Changes made**

- Replacing deprecated use of interaction response options `ephemeral` boolean
```diff
- interaction.reply({content: "Hello, World!", ephemeral: true})
+ interaction.reply({content: "Hello, World!",  flags: MessageFlags.Ephemeral})
```
-  Where flags were already implemented, use `MessageFlags` enum instead of hardcoded string
```diff
- interaction.reply({content: "Hello, World!", flags: 'Ephemeral'})
+ interaction.reply({content: "Hello, World!",  flags: MessageFlags.Ephemeral})
```

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [x] I have updated related documentation (if necessary)
- [x] My changes use consistent code style
- [x] My changes have been tested and confirmed to work
