### PR TITLE
feat(categories): Add customizable button styles

### DIFF
--- a/db/mysql/migrations/20250303181321_category_button_style/migration.sql
+++ b/db/mysql/migrations/20250303181321_category_button_style/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `categories` ADD COLUMN `buttonStyle` INTEGER NOT NULL DEFAULT 2;

--- a/db/mysql/schema.prisma
+++ b/db/mysql/schema.prisma
@@ -69,6 +69,7 @@ model ArchivedUser {
 }
 
 model Category {
+    buttonStyle     Int        @default(2)
     channelName     String
     claiming        Boolean    @default(false)
     createdAt       DateTime   @default(now())

--- a/db/postgresql/migrations/20250303182300_category_button_style/migration.sql
+++ b/db/postgresql/migrations/20250303182300_category_button_style/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "categories" ADD COLUMN     "buttonStyle" INTEGER NOT NULL DEFAULT 2;

--- a/db/postgresql/schema.prisma
+++ b/db/postgresql/schema.prisma
@@ -68,6 +68,7 @@ model ArchivedUser {
 }
 
 model Category {
+    buttonStyle     Int        @default(2)
     channelName     String
     claiming        Boolean    @default(false)
     createdAt       DateTime   @default(now())

--- a/db/sqlite/migrations/20250227205558_category_button_style/migration.sql
+++ b/db/sqlite/migrations/20250227205558_category_button_style/migration.sql
@@ -1,0 +1,33 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_categories" (
+    "buttonStyle" INTEGER NOT NULL DEFAULT 2,
+    "channelName" TEXT NOT NULL,
+    "claiming" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "cooldown" INTEGER,
+    "customTopic" TEXT,
+    "description" TEXT NOT NULL,
+    "discordCategory" TEXT NOT NULL,
+    "emoji" TEXT NOT NULL,
+    "enableFeedback" BOOLEAN NOT NULL DEFAULT false,
+    "guildId" TEXT NOT NULL,
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "image" TEXT,
+    "memberLimit" INTEGER NOT NULL DEFAULT 1,
+    "name" TEXT NOT NULL,
+    "openingMessage" TEXT NOT NULL,
+    "pingRoles" TEXT NOT NULL DEFAULT '[]',
+    "ratelimit" INTEGER,
+    "requiredRoles" TEXT NOT NULL DEFAULT '[]',
+    "requireTopic" BOOLEAN NOT NULL DEFAULT false,
+    "staffRoles" TEXT NOT NULL,
+    "totalLimit" INTEGER NOT NULL DEFAULT 50,
+    CONSTRAINT "categories_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guilds" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_categories" ("channelName", "claiming", "cooldown", "createdAt", "customTopic", "description", "discordCategory", "emoji", "enableFeedback", "guildId", "id", "image", "memberLimit", "name", "openingMessage", "pingRoles", "ratelimit", "requireTopic", "requiredRoles", "staffRoles", "totalLimit") SELECT "channelName", "claiming", "cooldown", "createdAt", "customTopic", "description", "discordCategory", "emoji", "enableFeedback", "guildId", "id", "image", "memberLimit", "name", "openingMessage", "pingRoles", "ratelimit", "requireTopic", "requiredRoles", "staffRoles", "totalLimit" FROM "categories";
+DROP TABLE "categories";
+ALTER TABLE "new_categories" RENAME TO "categories";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/db/sqlite/schema.prisma
+++ b/db/sqlite/schema.prisma
@@ -68,6 +68,7 @@ model ArchivedUser {
 }
 
 model Category {
+    buttonStyle     Int        @default(2)
     channelName     String
     claiming        Boolean    @default(false)
     createdAt       DateTime   @default(now())

--- a/src/routes/api/admin/guilds/[guild]/categories/[category]/index.js
+++ b/src/routes/api/admin/guilds/[guild]/categories/[category]/index.js
@@ -76,6 +76,7 @@ module.exports.patch = fastify => ({
 		const data = req.body;
 
 		const select = {
+			buttonStyle: true,
 			channelName: true,
 			claiming: true,
 			// createdAt: true,

--- a/src/routes/api/admin/guilds/[guild]/panels.js
+++ b/src/routes/api/admin/guilds/[guild]/panels.js
@@ -1,10 +1,7 @@
 const {
 	ActionRowBuilder,
 	ButtonBuilder,
-	ButtonStyle: {
-		Primary,
-		Secondary,
-	},
+	ButtonStyle: { Primary },
 	ChannelType: { GuildText },
 	EmbedBuilder,
 	StringSelectMenuBuilder,
@@ -100,7 +97,7 @@ module.exports.post = fastify => ({
 								action: 'create',
 								target: category.id,
 							}))
-							.setStyle(Secondary)
+							.setStyle(category.buttonStyle)
 							.setLabel(category.name)
 							.setEmoji(emoji.hasEmoji(category.emoji) ? emoji.get(category.emoji) : { id: category.emoji }),
 					),


### PR DESCRIPTION
<!--
	Thank you for contributing to Discord Tickets.
	If you haven't already, please read the CONTRIBUTING guidelines (https://github.com/discord-tickets/.github/blob/main/CONTRIBUTING.md) before creating a pull request.
	Unless this pull request is for something minor like a fixing a typo, you should create an issue first.
-->

**Versioning information**

<!-- Please select **one** by replacing the space with an `x`: `[X]` -->

- [ ] This includes major changes (breaking changes)
- [x] This includes minor changes (minimal usage changes, minor new features)
- [ ] This includes patches (bug fixes)
- [ ] This does not change functionality at all (code refactoring, comments)

**Is this related to an issue?**

<!-- Reference any issues here -->

**Changes made**

This change allows the user to select the category button style displayed in panels instead of always using `Secondary` (2). Adding colors to buttons makes it easier to distinguish between and direct users to the correct ticket category.

Example screenshot (panel with 4 categories):
<img width="412" height="79" alt="2025-08-02_16-09-39" src="https://github.com/user-attachments/assets/cb0d2d46-68b2-42c5-8a83-8b9f99bf5758" />

**Confirmations**

<!-- Select **all that apply** by replacing the space with an `x`: `[X]` -->

- [x] I have updated related documentation (if necessary) - https://github.com/discord-tickets/docs/pull/56
- [x] My changes use consistent code style
- [x] My changes have been tested and confirmed to work
